### PR TITLE
Excel dates as text transform

### DIFF
--- a/extras/lsu/xsl/dateCreatedSplit.xsl
+++ b/extras/lsu/xsl/dateCreatedSplit.xsl
@@ -42,7 +42,8 @@
     <xsl:variable name="priorRegEx" select="'[Pp]rior\sto\s([0-9]{4})|[Bb]efore\s([0-9]{4})'"/> <!-- prior to YYYY or before YYYY -->
     <xsl:variable name="questionableRegEx" select="'([0-9]{4})\(?\?\)?'"/> <!-- YYYY? or YYYY(?) -->
     <xsl:variable name="questionableRangeRegEx" select="'([0-9]{4})\(?\?\)?\s?-\s?([0-9]{4})\(?\?\)?'"/> <!-- YYYY?-YYYY? or YYYY? - YYYY? -->
-       
+    <xsl:variable name="serialnumber" select="'([0-9]{1,2})([-])([A-Z]{1}[a-z]{2})(-)([0-9]{1,2})'"/><!-- In the Excel spreadsheet, will display as 5 numbers, ie. the number of days since January 1, 1900, but will be written as 9-Oct-48 when exported-->
+      
     <xsl:template match="originInfo/dateCreated">
         <xsl:choose>
             <xsl:when test="matches(., $yearRangeRegEx) and not(matches(., 'Ca.'))">
@@ -281,6 +282,33 @@
                         <dateCreated keyDate="yes" point="end">
                             <xsl:value-of select="replace(regex-group(1), '\s+', ' ')"/>
                             <xsl:value-of select="replace(regex-group(2), '\s+', ' ')"/>
+                        </dateCreated>
+                    </xsl:matching-substring>
+                </xsl:analyze-string>
+            </xsl:when>
+            <xsl:when test="matches(., $serialnumber)">
+                <xsl:analyze-string select="." regex="{$serialnumber}">
+                    <xsl:matching-substring>
+                        <dateCreated keyDate="yes">
+                            <xsl:text>19</xsl:text>
+                            <xsl:value-of select="replace(regex-group(5), '\s', ' ')"/>
+                            <xsl:value-of select="replace(regex-group(2), '\s', ' ')"/>
+                            <xsl:choose>
+                                <xsl:when test="regex-group(3) = 'Jan'">01</xsl:when>
+                                <xsl:when test="regex-group(3) = 'Feb'">02</xsl:when>
+                                <xsl:when test="regex-group(3) = 'Mar'">03</xsl:when>
+                                <xsl:when test="regex-group(3) = 'Apr'">04</xsl:when>
+                                <xsl:when test="regex-group(3) = 'May'">05</xsl:when>
+                                <xsl:when test="regex-group(3) = 'Jun'">06</xsl:when>
+                                <xsl:when test="regex-group(3) = 'Jul'">07</xsl:when>
+                                <xsl:when test="regex-group(3) = 'Aug'">08</xsl:when>
+                                <xsl:when test="regex-group(3) = 'Sep'">09</xsl:when>
+                                <xsl:when test="regex-group(3) = 'Oct'">10</xsl:when>
+                                <xsl:when test="regex-group(3) = 'Nov'">11</xsl:when>
+                                <xsl:when test="regex-group(3) = 'Dec'">12</xsl:when>
+                            </xsl:choose>
+                            <xsl:value-of select="replace(regex-group(2), '\s', ' ')"/>
+                            <xsl:value-of select="replace(regex-group(1), '\s', ' ')"/>
                         </dateCreated>
                     </xsl:matching-substring>
                 </xsl:analyze-string>


### PR DESCRIPTION
When dates are formatted as text and exported from Excel, they take the form ?d-mon-yy. The $serialnumber variable and when test should transform this into yyyy-mm-dd.
What does this Pull Request do?

This pull request adds a date transformation to dateCreatedSplit that should properly transform dates natively exported from Excel.
What's new?

Expected results:
Delcroix 1984.189.22 has 10/9/1948 in the date column. In output\xslt-0\22.xml, it has 9-Oct-48. In output\xslt-3-dateCreatedSplit\22.xml it is transformed to 1948-10-9 and this remains the result in the final xml for upload.

Possible errors: Single digit days, like the one above, are not being transformed to include a leading 0, despite the added code in lines 311-318.

Error with unknown origin:
Though the process works on delcroix file 22, it doesn't work on some of the expected files. This seems to be due to a mistake elsewhere in the transformation because their dates in the first step of the post-write-scripts do not match the contents of the metadata file (1984.189.72 has 4/28/2005 in the metadata.csv, but 19301950 in \output\hnoc-xslt\xslt-0\72.xml.
How should this be tested?

A description of what steps someone could take to:

    Reproduce the problem you are fixing (if applicable)
        Test to see if your dates follow this pattern--it may be immediately visible, but the numbers in excel which when transformed to text become a five-digit number should also be effected by this addition
    Test that the Pull Request does what is intended.
        Add this script to your config file on a csv that includes the aforementioned type of dates results should be yyyy-mm-dd
    Provide some sample data for testers.
        the sample metadata in LSU's MIK has applicable dates

Additional Notes:

@rtilla1 will be working on adding a test to add a leading zero to the single-digit dates, but would appreciate if someone can duplicate the issue of dates in the spreadsheet transforming to the wrong strings in the first step of post-write-hooks. They're willing to help solve the problem provided it gets identified.

If this change is accepted, another date format can be added to the accepted forms. It also supports the work Mark Jordan et al. are doing to make MIK work well with excel documents (instead of a transformation to .csv or .txt being required). It should not otherwise effect the code.